### PR TITLE
fix lazyloading logout bug

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,6 +27,11 @@ export class MyApp {
       this.rootPage = LoginPage;
     });
 
+    events.subscribe('user:manualLogout', () => {
+      this.nav.push(LoginPage, {'manualLogout': true});
+      this.rootPage = LoginPage;
+    });
+
     // navigate to tabspage
     events.subscribe('user:login', () => {
       this.nav.push(TabsPage);

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -21,11 +21,12 @@ export class LoginPage {
     this.debug = false;
     this.loggedOut = true;
 
-    events.subscribe('user:manualLogout', () => {
-      this.loggedOut = true;
-      this.events.publish('user:logout');
-    });
+  }
 
+  ionViewWillEnter() {
+    if (this.navParams.get('manualLogout')) {
+      this.loggedOut = true;
+    }
   }
   
   resetCredentials() {

--- a/src/pages/oncall-team/oncall-team.ts
+++ b/src/pages/oncall-team/oncall-team.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams, ToastController } from 'ionic-angular';
+import { NavController, NavParams, ToastController, Events } from 'ionic-angular';
 import { IrisProvider, OncallTeam} from '../../providers/iris/iris';
+import { IrisInfoProvider } from '../../providers/iris_info/iris_info';
 import { OncallUserPage } from '../oncall-user/oncall-user';
 
 
@@ -13,12 +14,19 @@ export class OncallTeamPage {
   loading: boolean;
   loadingError: boolean;
 
-  constructor(public navCtrl: NavController, public navParams: NavParams, public iris: IrisProvider, private toastCtrl: ToastController) {
+  constructor(public events: Events, public navCtrl: NavController, public navParams: NavParams, public iris: IrisProvider, private irisInfo: IrisInfoProvider, private toastCtrl: ToastController) {
   }
 
   objectKeys = Object.keys;
 
   ionViewWillEnter() {
+
+    if (!this.irisInfo.username) {
+      // remove tab navigation on logout
+      this.events.publish('user:logout');
+      return;
+    }
+
     this.getTeam();
   }
 

--- a/src/pages/oncall-user/oncall-user.ts
+++ b/src/pages/oncall-user/oncall-user.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams, ToastController, ActionSheetController } from 'ionic-angular';
+import { NavController, NavParams, ToastController, ActionSheetController, Events } from 'ionic-angular';
 import { IrisProvider, OncallUser } from '../../providers/iris/iris';
 import { OncallTeamPage } from '../oncall-team/oncall-team';
 import { IrisInfoProvider } from '../../providers/iris_info/iris_info';
@@ -20,10 +20,17 @@ export class OncallUserPage {
   loadingError: boolean;
   mePageBool: boolean = false;
 
-  constructor(public navCtrl: NavController, public navParams: NavParams, private actionCtrl: ActionSheetController, private logOut: LogoutProvider, public iris: IrisProvider, private irisInfo: IrisInfoProvider, private toastCtrl: ToastController, private sanitizer: DomSanitizer) {
+  constructor(public events: Events, public navCtrl: NavController, public navParams: NavParams, private actionCtrl: ActionSheetController, private logOut: LogoutProvider, public iris: IrisProvider, private irisInfo: IrisInfoProvider, private toastCtrl: ToastController, private sanitizer: DomSanitizer) {
   }
 
   ionViewWillEnter() {
+
+    if (!this.irisInfo.username) {
+      // remove tab navigation on logout
+      this.events.publish('user:logout');
+      return;
+    }
+
     if (this.navParams.get('username')) {
       this.mePageBool = false;
       this.getUser();

--- a/src/pages/oncall/oncall.ts
+++ b/src/pages/oncall/oncall.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams, ActionSheetController, ToastController } from 'ionic-angular';
+import { NavController, NavParams, ActionSheetController, ToastController, Events  } from 'ionic-angular';
 
 import { LogoutProvider } from '../../providers/logout/logout';
 import { OncallUserPage } from '../oncall-user/oncall-user';
@@ -31,13 +31,20 @@ export class OncallPage {
   loadingError: boolean = false;
 
 
-  constructor(private logOut: LogoutProvider, public navCtrl: NavController,
+  constructor(public events: Events, public navCtrl: NavController, private logOut: LogoutProvider,
     public navParams: NavParams, private actionCtrl: ActionSheetController,
     private iris: IrisProvider, private toastCtrl: ToastController,
     private irisInfo: IrisInfoProvider) {
   }
 
   ionViewWillEnter() {
+
+    if (!this.irisInfo.username) {
+      // remove tab navigation on logout
+      this.events.publish('user:logout');
+      return;
+    }
+
     // pinned teams display on call now data so make sure they are up to date every time
     this.pinnedTeamsLoading = true;
     this.initPinnedTeams();

--- a/src/pages/privacy-policy/privacy-policy.ts
+++ b/src/pages/privacy-policy/privacy-policy.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
-import { NavController, NavParams } from 'ionic-angular';
+import { NavController, NavParams, Events } from 'ionic-angular';
 import { InAppBrowser } from '@ionic-native/in-app-browser';
+import { IrisInfoProvider } from '../../providers/iris_info/iris_info';
 
 
 @Component({
@@ -9,13 +10,20 @@ import { InAppBrowser } from '@ionic-native/in-app-browser';
 })
 export class PrivacyPolicyPage {
 
-  constructor(public navCtrl: NavController, public navParams: NavParams, private iab: InAppBrowser) {
+  constructor(public events: Events, public navCtrl: NavController, public navParams: NavParams, private iab: InAppBrowser, private irisInfo: IrisInfoProvider) {
     
   }
 
   public configPrivacyPolicyUrl: string = process.env.PRIVACY_POLICY_URL;
 
   ionViewWillEnter() {
+
+    if (!this.irisInfo.username) {
+      // remove tab navigation on logout
+      this.events.publish('user:logout');
+      return;
+    }
+
     const browser = this.iab.create(this.configPrivacyPolicyUrl);
     browser.show();
   }


### PR DESCRIPTION
Because login page is lazy loaded it is possible for that page to never subscribe to the manualLogout event which would cause logout to fail. Fix this by moving the event subscription to app.component.ts and instead pass that information to the login page through a param in nav.push()